### PR TITLE
Add individual-testpaths option

### DIFF
--- a/detect_test_pollution.py
+++ b/detect_test_pollution.py
@@ -97,14 +97,6 @@ def _discover_tests(path: str) -> list[str]:
         return _parse_testids_file(testids_filename)
 
 
-def _common_testpath(testids: list[str]) -> str:
-    paths = [testid.split('::')[0] for testid in testids]
-    if not paths:
-        return '.'
-    else:
-        return os.path.commonpath(paths) or '.'
-
-
 def _individual_testpaths(testids: list[str]) -> list[str]:
     paths = {testid.split('::')[0] for testid in testids}
     if not paths:
@@ -262,16 +254,6 @@ def _bisect(
 def main(argv: Sequence[str] | None = None) -> int:
     parser = argparse.ArgumentParser()
 
-    parser.add_argument(
-        '-i',
-        '--individual-testpaths',
-        action='store_true',
-        help=(
-            'Use individual testpaths instead of common one for pytest runs. '
-            'Useful if not all test dependencies are installed.'
-        ),
-    )
-
     mutex1 = parser.add_mutually_exclusive_group(required=True)
     mutex1.add_argument(
         '--fuzz',
@@ -306,10 +288,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         testids = _discover_tests(args.tests)
         print(f'-> discovered {len(testids)} tests!')
 
-    if args.individual_testpaths:
-        testpaths = _individual_testpaths(testids)
-    else:
-        testpaths = [_common_testpath(testids)]
+    testpaths = _individual_testpaths(testids)
 
     if args.fuzz:
         return _fuzz(testpaths, testids, args.tests, args.testids_file)

--- a/tests/detect_test_pollution_test.py
+++ b/tests/detect_test_pollution_test.py
@@ -5,7 +5,6 @@ import json
 import pytest
 
 import detect_test_pollution
-from detect_test_pollution import _common_testpath
 from detect_test_pollution import _discover_tests
 from detect_test_pollution import _format_cmd
 from detect_test_pollution import _individual_testpaths
@@ -110,20 +109,6 @@ def test_discover_tests(tmp_path):
     f.write_text('def test_one(): pass\ndef test_two(): pass\n')
 
     assert _discover_tests(f) == ['t.py::test_one', 't.py::test_two']
-
-
-@pytest.mark.parametrize(
-    ('inputs', 'expected'),
-    (
-        ([], '.'),
-        (['a', 'a/b'], 'a'),
-        (['a', 'b'], '.'),
-        (['a/b/c', 'a/b/d', 'a/b/e'], 'a/b'),
-        (['a/b/c', 'a/b/c'], 'a/b/c'),
-    ),
-)
-def test_common_testpath(inputs, expected):
-    assert _common_testpath(inputs) == expected
 
 
 @pytest.mark.parametrize(
@@ -307,7 +292,6 @@ def test_k2():
         ret = main((
             '--testids-file', str(testlist),
             '--failing-test', 't.py::test_k',
-            '--individual-testpaths',
         ))
     assert ret == 0
 


### PR DESCRIPTION
Sometimes it's not possible to have all test dependencies installed locally. That isn't an issue as long as pytest is called with the specific test files. The issue here is that `_common_testpath` can result in pytest attempting a test discovery in a parent package for which not all dependencies might be installed.

The new `--individual-testpaths` option in this PR would help with that.