### PR TITLE
Add install requirement for pytest

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -17,6 +17,8 @@ classifiers =
 
 [options]
 py_modules = detect_test_pollution
+install_requires =
+    pytest>=7.4.3
 python_requires = >=3.10
 
 [options.entry_points]


### PR DESCRIPTION
While making explains videos, I installed `detect-test-pollution` without having the `pytest` pre-installed.
I just wanted to double check the CLI arguments with the help flag and I encountered exception for missing `pytest`:

```bash
$ pip install detect-test-pollution
$ detect-test-pollution --help
Traceback (most recent call last):
  File "/home/opc/venv/bin/detect-test-pollution", line 3, in <module>
    from detect_test_pollution import main
  File "/home/opc/venv/lib/python3.12/site-packages/detect_test_pollution.py", line 15, in <module>
    import pytest
ModuleNotFoundError: No module named 'pytest'
```

I thought it would be helpful to resolve this for folks that doesn't have `pytest` pre-installed.
Most folks will have it anyways and it will not harm adding an install requirement.

Same thing happens when the user tries to check the version wth `detect-test-pollution --version`

And why particularly from `v7.4.3` onwards - because the corresponding typing definitions used by `detect-test-pollution` were added in this version of `pytest`.